### PR TITLE
Previously notified users

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -32,7 +32,8 @@ jobs:
         - name: Notify Slack
           uses: kapost/slack-notification@script-update
           env:
-            S3_URL: s3://my-bucket/path/to/mapping.yml
+            MAPPING_URL: s3://my-bucket/path/to/mapping.yml
+            NOTIFIED_USERS_URL: s3://my-bucket/pull-requests/app/${{ github.event.pull_request.number }}/notified-users.txt
             PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
             PR_NUMBER: ${{ github.event.pull_request.number }}
             GITHUB_REPO: kapost/slack-notification

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # slack-notification
-This action creates a docker container that notifies Slack users when they're requested to review a pull request. The `entrypoint.sh` script pulls a YAML formatting mapping file from S3 in order to map GitHub users to their respective Slack channels. GitHub teams and users can be specified in the mapping file. 
+This action creates a docker container that notifies Slack users when they're requested to review a pull request. The `entrypoint.sh` script pulls a YAML formatting mapping file from S3 in order to map GitHub users to their respective Slack channels. GitHub teams and users can be specified in the mapping file. A `NOTIFIED_USERS_URL` is specified in order to store or read users that have already been notified. This is to be stored in an S3 bucket similar to the `MAPPING_URL`.
 
 # Usage
 
@@ -40,7 +40,8 @@ jobs:
         - name: Notify Slack
           uses: kapost/slack-notification@script-update
           env:
-            S3_URL: s3://my-bucket/path/to/mapping.yml
+            MAPPING_URL: s3://my-bucket/path/to/mapping.yml
+            NOTIFIED_USERS_URL: s3://my-bucket/pull-requests/app1/${{ github.event.pull_request.number }}/notified-users.txt
             PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
             PR_NUMBER: ${{ github.event.pull_request.number }}
             GITHUB_REPO: kapost/slack-notification
@@ -51,12 +52,13 @@ jobs:
 ### Variables
 | Variable | Usage | Example |
 | ---- | ---- | ---- |
-| S3_URL | URL of the S3 mapping file | s3://my-bucket/path/to/mapping.yml |
-| PAT_TOKEN | Personal Access Token with permissions to read reviewers and pull requests | ghp_MyTokenCreatedInGithub |
-| PR_NUMBER | Pull Request Number - Advised to pull from the Pull Request event | 1 |
-| GITHUB_REPO | GitHub Owner and Repository | kapost/slack-notification |
-| PR_MESSAGE | Message to send to the Slack user(s) or channel(s) | "Hello World!" |
-| PR_WEBHOOK_URL | Slack Webhook URL | https://hooks.slack.com/services/ABCD/ABCD1234 |
+| `MAPPING_URL` | URL of the S3 mapping file | s3://my-bucket/path/to/mapping.yml |
+| `NOTIFIED_USERS_URL` | URL of the notified users file - does not have to exist but must be specified in order to create one | s3://my-bucket/pull-requests/app/${{ github.event.pull_request.number }}/notified-users.txt |
+| `PAT_TOKEN` | Personal Access Token with permissions to read reviewers and pull requests | ghp_MyTokenCreatedInGithub |
+| `PR_NUMBER` | Pull Request Number - Advised to pull from the Pull Request event | 1 |
+| `GITHUB_REPO` | GitHub Owner and Repository | kapost/slack-notification |
+| `PR_MESSAGE` | Message to send to the Slack user(s) or channel(s) | "Hello World!" |
+| `PR_WEBHOOK_URL` | Slack Webhook URL | https://hooks.slack.com/services/ABCD/ABCD1234 |
 
 ## Mapping YAML Example
 S3 [user-mapping.yml](user-mapping.yml)
@@ -64,14 +66,28 @@ S3 [user-mapping.yml](user-mapping.yml)
 github_to_slack_mapping:
   thatsnotamuffin: # <-- GitHub User
     slack_username: "@thatsnotamuffin" # <-- Slack User
-  muffin1:
-    slack_username: "@muffin1"
-  muffin2:
-    slack_username: "@muffin2"
-  muffin-team: # <-- GitHub Team
-    slack_username: "#muffin-chat" # <-- Slack Channel
+  kapuser1:
+    slack_username: "@kapuser1"
+  kapuser2:
+    slack_username: "@kapuser2"
+  kapuser-team: # <-- GitHub Team
+    slack_username: "#kapuser-chat" # <-- Slack Channel
 ```
 
 # Versions
 ## v1
-This version only supports Incoming WebHooks custom integrations. This is a legacy custom integration in Slack. Later this action will be updated to support mapping users and channels to individual Webhook URL
+This version only supports Incoming WebHooks custom integrations. This is a legacy custom integration in Slack. Later this action will be updated to support mapping users and channels to individual Webhook URLs
+
+## v2
+This version only supports Incoming WebHooks custom integrations. This is a legacy custom integration in Slack. Later this action will be updated to support mapping users and channels to invidual WebHook URLs
+
+Added support to prevent notifying the same user multiple times if other users are requested to review. This is done by adding the `NOTIFIED_USERS_URL` argument. This argument must be specified in order to read or create the file of users that have already been notified. As of the moment, this loops over the file denoted by new lines. 
+
+It is important that the `NOTIFIED_USERS_URL` argument is unique to each pull request, otherwise conflicts may occur between multiple pull requests trying to read the same user file. In the example above this is done by using a `pull-requests/app1` directory, then each `notified-users.txt` file are stored within directories that are separated by their pull request number that is generated from the `github pull request event`.
+
+Example Formatting in a `notified-users.txt` file
+```txt
+kapuser1
+kapuser2
+kapuser-team
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,9 @@ if aws s3 ls "$NOTIFIED_USERS_URL" >/dev/null 2>&1; then
         done
     done < $NOTIFIED_USERS_FILE
 
+    # Delete and re-create the notified users file
     rm $NOTIFIED_USERS_FILE
+    touch $NOTIFIED_USERS_FILE
 
     for i in ${reviewer_list[@]}; do
         echo $i >> $NOTIFIED_USERS_FILE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@
 set -xe
 
 # Download Mapping File
-aws s3 cp $S3_URL .
-MAPPING_FILE=$(basename $S3_URL)
+aws s3 cp $MAPPING_URL .
+MAPPING_FILE=$(basename $MAPPING_URL)
 
 echo $PAT_TOKEN | gh auth login --with-token
 
@@ -13,11 +13,39 @@ pr_info=$(gh pr view $PR_NUMBER -R $GITHUB_REPO --json reviewRequests)
 individual_reviewers=$(echo "$pr_info" | jq -r '.reviewRequests[] | select(.__typename == "User") | .login')
 team_reviewers=$(echo "$pr_info" | jq -r '.reviewRequests[] | select(.__typename == "Team") | .slug')
 combined_reviewers="${individual_reviewers} ${team_reviewers}"
+       
 
 reviewer_list=()
 while read -r user; do
     reviewer_list+=("$user")
 done <<< "$combined_reviewers"
+
+# Check if notified users file already exists and if not, create the file and populate it with users in reviewer_list
+if aws s3 ls "$NOTIFIED_USERS_URL" >/dev/null 2>&1; then
+    # Notified users file exists, remove the already notified users from reviewer_list and update the file
+    aws s3 cp $NOTIFIED_USERS_URL .
+    NOTIFIED_USERS_FILE=$(basename $NOTIFIED_USERS_URL)
+
+    while IFS= read -r username; do
+        for i in "${!reviewer_list[@]}"; do
+            if [[ ${reviewer_list[i]} == "$username" ]]; then
+            unset 'reviewer_list[i]'
+            fi
+        done
+    done < $NOTIFIED_USERS_FILE
+
+    rm $NOTIFIED_USERS_FILE
+
+    for i in ${reviewer_list[@]}; do
+        echo $i >> $NOTIFIED_USERS_FILE
+    done
+else
+    # Notified users file does not exist, populate the file with users in reviewer_list
+    NOTIFIED_USERS_FILE=$(basename $NOTIFIED_USERS_URL)
+    for i in ${reviewer_list[@]}; do
+        echo $i >> $NOTIFIED_USERS_FILE
+    done
+fi
 
 # Parse YAML file and message users
 for i in ${reviewer_list[@]}; do 
@@ -30,3 +58,6 @@ for i in ${reviewer_list[@]}; do
 
     curl -X POST -H 'Content-type: application/json' --data "${json_payload}" $PR_WEBHOOK_URL;
 done
+
+# Upload notified users file
+aws s3 cp $NOTIFIED_USERS_FILE $NOTIFIED_USERS_URL


### PR DESCRIPTION
Adding support to prevent messaging users and channels repeatedly for the same pull request whenever new reviewers are added.